### PR TITLE
fix: docker-compose.yml 환경 변수 파싱 오류 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services: # 이 파일로 관리할 서비스(컨테이너)들의 목록을 정�
       dockerfile: Dockerfile # 사용할 Dockerfile 이름 (기본값이라 생략 가능)
     ports:
       - "8080:8080" # 호스트포트:컨테이너포트 매핑 (이전 docker run -p 와 동일)
-    environment:
+    environment: {}
       # 여기에 필요한 환경 변수를 설정할 수 있다 (예: 데이터베이스 정보 등)
       # 예시: SPRING_PROFILES_ACTIVE: prod
       # (주의!) API 키 같은 민감 정보는 여기에 직접 적지 않는 것이 좋다 (다른 방법 사용)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+# docker-compose.yml (프로젝트 루트 폴더에 위치)
+
+version: '3.8' # Docker Compose 파일 형식 버전을 지정한다 (최신 버전 중 하나)
+
+services: # 이 파일로 관리할 서비스(컨테이너)들의 목록을 정의한다
+
+  # --- 백엔드 서비스 정의 ---
+  backend: # 서비스 이름 (컨테이너 간 통신 시 이 이름 사용 가능)
+    container_name: weather-map-backend-container # 생성될 컨테이너 이름 지정 (선택사항)
+    build:
+      context: ./backend # Dockerfile이 있는 경로 (현재 폴더 아래 backend 폴더)
+      dockerfile: Dockerfile # 사용할 Dockerfile 이름 (기본값이라 생략 가능)
+    ports:
+      - "8080:8080" # 호스트포트:컨테이너포트 매핑 (이전 docker run -p 와 동일)
+    environment:
+      # 여기에 필요한 환경 변수를 설정할 수 있다 (예: 데이터베이스 정보 등)
+      # 예시: SPRING_PROFILES_ACTIVE: prod
+      # (주의!) API 키 같은 민감 정보는 여기에 직접 적지 않는 것이 좋다 (다른 방법 사용)
+    networks: # 사용할 네트워크 지정 (아래 networks 섹션에서 정의)
+      - weather_map_network
+
+  # --- 프론트엔드 서비스 정의 ---
+  frontend: # 서비스 이름
+    container_name: weather-map-frontend-container # 컨테이너 이름
+    build:
+      context: ./frontend # Dockerfile 경로
+      dockerfile: Dockerfile
+    ports:
+      - "8081:80" # 호스트 8081 -> 컨테이너(Nginx) 80
+    depends_on: # 의존성 설정: 백엔드 서비스가 먼저 시작된 후 프론트엔드가 시작되도록 (선택사항)
+      - backend
+    networks:
+      - weather_map_network
+
+networks: # 컨테이너들이 사용할 네트워크 정의
+  weather_map_network: # 네트워크 이름
+    driver: bridge # 가장 일반적인 네트워크 드라이버 (기본값)


### PR DESCRIPTION
주석 처리된 environment 항목이 파싱 오류를 일으켜 빈 객체({})로 명시적으로 수정함.